### PR TITLE
CVE 2022 42743

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,9 +28,9 @@ function deepParseJson(jsonString) {
     // typeof null returns 'object' too, so we have to eliminate that
     return Object.keys(jsonString).reduce((obj, key) => {
       const val = jsonString[key];
-      obj[key] = isNumString(val) ? val : deepParseJson(val);
+      obj[key] = deepParseJson(val);
       return obj;
-    }, {});
+    }, Object.create(null));
   } else {
     // otherwise return whatever was received
     return jsonString;


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2022-42743

    Using Object.create(null) for initialization to prevent prototype pollution, as recommended by https://cwe.mitre.org/data/definitions/1321.html
    
    Removed extraneous check for string being a number, as that check is already performed in the next recursive call.
